### PR TITLE
feat(cert.sh): 设置默认 CA 为 Let's Encrypt

### DIFF
--- a/cert.sh
+++ b/cert.sh
@@ -44,6 +44,9 @@ git clone https://github.com/Neilpang/acme.sh.git
 cd acme.sh
 ./acme.sh --install --home ~/.acme.sh
 
+# 设置默认 CA
+~/.acme.sh/acme.sh --set-default-ca  --server  letsencrypt
+
 # 生成证书
 echo -e "${Info} 证书路径：${certFolder}"
 mkdir ${certFolder}


### PR DESCRIPTION
acme.sh v3.0 将使用 ZeroSLL 为默认 CA

https://github.com/acmesh-official/acme.sh/wiki/Change-default-CA-to-ZeroSSL